### PR TITLE
Make `AtomixRequestCounter#consume` cold (for retries)

### DIFF
--- a/rate-limiter-atomix/src/main/java/org/springframework/cloud/gateway/ratelimiter/AtomixRequestCounter.java
+++ b/rate-limiter-atomix/src/main/java/org/springframework/cloud/gateway/ratelimiter/AtomixRequestCounter.java
@@ -17,7 +17,7 @@ public class AtomixRequestCounter implements RequestCounter {
 
 	@Override
 	public Mono<ConsumeResponse> consume(String apiKey) {
-		return Mono.fromFuture(requestCount.incrementAndGet(getKey(apiKey)))
+		return Mono.fromFuture(() -> requestCount.incrementAndGet(getKey(apiKey)))
 		           .map(noRequests -> {
 			           if (noRequests > limit) {
 				           return new ConsumeResponse(false, 0, 0);


### PR DESCRIPTION
To be able to use retries and repeats and other Reactor's features, it is highly recommended to return cold `Publisher`s if possible.
You can read about the difference here:
https://projectreactor.io/docs/core/release/reference/#reactor.hotCold

In your case, you start `incrementAndGet` when somebody calls `#consume` even before the result of the method gets subscribed, and the current code is an equivalent of:
```java
CompletionStage<Integer> future = requestCount.incrementAndGet(getKey(apiKey));
return Mono.fromFuture(future)
        // ... more operators here
```
Even if somebody uses `.retry(3)` downside to retry `consume` on error, it will always reuse that `future` without retrying the increment.

However, there is a special overload of `Mono.fromFuture` that takes a `Supplier<CompletionStage<T>>` instead, and, as long as you create a future inside the future, returns a cold publisher.